### PR TITLE
Pre-commit config updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -21,7 +21,7 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
@@ -37,7 +37,7 @@ repos:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.89.0
+    rev: v1.107.0
     hooks:
       - id: semgrep
   - repo: https://github.com/Yelp/detect-secrets
@@ -52,8 +52,25 @@ repos:
     rev: main
     hooks:
       - id: build-docs
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: copyright
-      # - id: package-app-dependencies
-      # - id: notice-file
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
+      - id: package-app-dependencies
+        language: python
+        additional_dependencies: ["local-hooks"]
+      - id: notice-file
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: release-notes
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
       - id: static-tests
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* chore(ci): Pre-commit config updates


### PR DESCRIPTION
- Enable package_app_dependency pre-commit hook
- Enable generate_notice pre-commit hook
- All pre-commit hooks besides package_app_dependencies now require args
- Workflow file updates

[_Created by Sourcegraph batch change `mnordby-splunk/003-pre-commit-updates`._](https://sourcegraph.splunkdev.net/users/mnordby-splunk/batch-changes/003-pre-commit-updates)