### PR TITLE
fix: harden ThreatConnect connector requests [Codex]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: ThreatConnect
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Escape hunt-action values before using them in ThreatConnect Query Language filters.
 * Retain the ThreatConnect polling checkpoint when an indicator cannot be saved.
 * Retrieve all ThreatConnect indicator pages needed for each polling window.
+* Ingest malformed CIDR and Registry Key indicators without halting later poll results. [PSAAS-32854]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Verify ThreatConnect server certificates by default for new and existing assets without an explicit setting.
 * Escape hunt-action values before using them in ThreatConnect Query Language filters.
 * Retain the ThreatConnect polling checkpoint when an indicator cannot be saved.
+* Retrieve all ThreatConnect indicator pages needed for each polling window.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Verify ThreatConnect server certificates by default for new and existing assets without an explicit setting.
 * Escape hunt-action values before using them in ThreatConnect Query Language filters.
+* Retain the ThreatConnect polling checkpoint when an indicator cannot be saved.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Verify ThreatConnect server certificates by default for new and existing assets without an explicit setting.
+* Escape hunt-action values before using them in ThreatConnect Query Language filters.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Verify ThreatConnect server certificates by default for new and existing assets without an explicit setting.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,7 @@
 **Unreleased**
 
+* Refresh development validation tooling. [PSAAS-32854]
+
 * Verify ThreatConnect server certificates by default for new and existing assets without an explicit setting.
 * Escape hunt-action values before using them in ThreatConnect Query Language filters.
 * Retain the ThreatConnect polling checkpoint when an indicator cannot be saved.

--- a/threatconnect.json
+++ b/threatconnect.json
@@ -55,7 +55,8 @@
         "verify_server_cert": {
             "data_type": "boolean",
             "order": 1,
-            "description": "Verify server cert"
+            "description": "Verify server cert",
+            "default": true
         }
     },
     "actions": [

--- a/threatconnect.json
+++ b/threatconnect.json
@@ -19,7 +19,7 @@
     ],
     "publisher": "Splunk",
     "package_name": "phantom_threatconnect",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "configuration": {
         "access_id": {
             "data_type": "string",

--- a/threatconnect_connector.py
+++ b/threatconnect_connector.py
@@ -799,7 +799,7 @@ class ThreatconnectConnector(BaseConnector):
                 params=params,
                 json=body,
                 headers=headers,
-                verify=config.get("verify_server_cert", False),
+                verify=config.get("verify_server_cert", True),
             )
         except Exception as e:
             # Set the action_result status to error, the handler function will most probably return as is

--- a/threatconnect_connector.py
+++ b/threatconnect_connector.py
@@ -347,17 +347,38 @@ class ThreatconnectConnector(BaseConnector):
         self.save_progress("Making REST call for ingestion")
 
         endpoint = THREATCONNECT_ENDPOINT_INDICATOR_BASE
+        result_limit = 100
+        result_start = 0
+        indicators = []
+        start_time_unix = int(parse_datetime(start_time).strftime("%s"))
 
-        ret_val, resp_json = self._make_rest_call(action_result, endpoint)
+        while True:
+            params = {
+                "sorting": "dateAdded desc",
+                "resultLimit": result_limit,
+                "resultStart": result_start,
+            }
+            ret_val, resp_json = self._make_rest_call(action_result, endpoint, params=params)
 
-        if phantom.is_fail(ret_val):
-            self.save_progress("REST Call failed during ingestion")
+            if phantom.is_fail(ret_val):
+                self.save_progress("REST Call failed during ingestion")
 
-            return self.set_status(phantom.APP_ERROR)
+                return self.set_status(phantom.APP_ERROR)
+
+            page = resp_json.get("data", [])
+            indicators.extend(page)
+            if len(page) < result_limit:
+                break
+
+            oldest_on_page = int(parse_datetime(page[-1]["dateAdded"]).strftime("%s"))
+            if oldest_on_page < start_time_unix:
+                break
+
+            result_start += result_limit
 
         self.save_progress("Saving containers and artifacts")
 
-        ret_val, message = self._create_containers(resp_json, start_time)
+        ret_val, message = self._create_containers({"data": indicators}, start_time)
 
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, message)

--- a/threatconnect_connector.py
+++ b/threatconnect_connector.py
@@ -1,6 +1,6 @@
 # File: threatconnect_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -179,9 +179,7 @@ class ThreatconnectConnector(BaseConnector):
             else:
                 owners_list = [owner.strip() for owner in owners.replace(";", ",").split(",") if owner.strip()]
 
-            payload["tql"] += " and ownerName in ({})".format(
-                ", ".join(f"'{self._escape_tql_literal(owner)}'" for owner in owners_list)
-            )
+            payload["tql"] += " and ownerName in ({})".format(", ".join(f"'{self._escape_tql_literal(owner)}'" for owner in owners_list))
 
         return phantom.APP_SUCCESS, payload
 

--- a/threatconnect_connector.py
+++ b/threatconnect_connector.py
@@ -417,6 +417,9 @@ class ThreatconnectConnector(BaseConnector):
         container_limit = self._container_limit if self._container_limit < len(indicator_list) else len(indicator_list)
 
         successful_container_count = 0
+        failed_indicator_count = 0
+        checkpoint = None
+        checkpoint_error = None
 
         beginning_of_polling_date = indicator_list[-1]["dateAdded"]
 
@@ -459,41 +462,54 @@ class ThreatconnectConnector(BaseConnector):
 
             # Create the container
             ret_val, container_message, id = self.save_container(container)
-
-            # Increment the container count if container not dupicate
-            if "duplicate" not in container_message.lower():
-                successful_container_count += 1
+            if phantom.is_fail(ret_val):
+                self.debug_print(f"Failed to save container for indicator {indicator['id']}: {container_message}")
+                failed_indicator_count += 1
+                continue
 
             # Pull the ID from the container and add it to the artifact
             artifact["container_id"] = id
 
             # Add the artifact to that container
             ret_val, artifact_message, id = self.save_artifact(artifact)
+            if phantom.is_fail(ret_val):
+                self.debug_print(f"Failed to save artifact for indicator {indicator['id']}: {artifact_message}")
+                failed_indicator_count += 1
+                continue
+
+            # Increment the container count if container not duplicate
+            if "duplicate" not in container_message.lower():
+                successful_container_count += 1
 
             # Break the loop when the container_limit set in the config is reached.
             if successful_container_count == container_limit:
                 # Only update the state file if its not poll now
-                if phantom.is_fail(self.is_poll_now()):
+                if not self.is_poll_now():
                     # Update the state in order to use the correct date for the next ingestion cycle.
                     date_to_use = self._state.get(THREATCONNECT_JSON_LAST_DATE_TIME)
 
                     if date_to_use is None:
-                        self._state[THREATCONNECT_JSON_LAST_DATE_TIME] = beginning_of_polling_date
+                        checkpoint = beginning_of_polling_date
                     elif date_to_use == indicator["dateAdded"]:
-                        start_time = (parse_datetime(indicator["dateAdded"]) + timedelta(seconds=1)).strftime(DATETIME_FORMAT)
-
-                        self._state[THREATCONNECT_JSON_LAST_DATE_TIME] = start_time
-
-                        return (
-                            phantom.APP_ERROR,
+                        checkpoint = (parse_datetime(indicator["dateAdded"]) + timedelta(seconds=1)).strftime(DATETIME_FORMAT)
+                        checkpoint_error = (
                             "Some indicators may have been dropped due to max containers being "
                             "smaller than the amount of indicators in a given second.  Please increase "
-                            "the max_containers in order to ensure no dropped indicators.",
+                            "the max_containers in order to ensure no dropped indicators."
                         )
                     else:
                         # As long as the indicator date and the date in the state are not the same then replace it
-                        self._state[THREATCONNECT_JSON_LAST_DATE_TIME] = indicator["dateAdded"]
+                        checkpoint = indicator["dateAdded"]
                 break
+
+        if failed_indicator_count:
+            return phantom.APP_ERROR, f"{failed_indicator_count} indicator(s) failed to ingest; checkpoint not advanced"
+
+        if checkpoint:
+            self._state[THREATCONNECT_JSON_LAST_DATE_TIME] = checkpoint
+
+        if checkpoint_error:
+            return phantom.APP_ERROR, checkpoint_error
 
         return phantom.APP_SUCCESS, ("Success" if successful_container_count else "No new indicators found")
 

--- a/threatconnect_connector.py
+++ b/threatconnect_connector.py
@@ -667,12 +667,20 @@ class ThreatconnectConnector(BaseConnector):
         if indicator_type == "mutex":
             return "Mutex Artifact", "mutex", None
         if indicator_type == "cidr":
+            if "/" not in summary:
+                return None, None, None
+            try:
+                ipaddress.ip_network(summary, strict=False)
+            except ValueError:
+                return None, None, None
             return (
                 "CIDR Artifact",
                 ["deviceAddress", "cidrPrefix", "cidr"],
                 ["ip", None, "CIDR"],
             )
         elif indicator_type == "registry key":
+            if len(summary.split(" : ")) != 3:
+                return None, None, None
             return "Registry Key Artifact", "registryKey", None
         elif indicator_type == "asn":
             return "ASN Artifact", "asn", None

--- a/threatconnect_connector.py
+++ b/threatconnect_connector.py
@@ -137,6 +137,9 @@ class ThreatconnectConnector(BaseConnector):
         # _hunt_host action
         return self._hunt_indicator(param)
 
+    def _escape_tql_literal(self, value):
+        return str(value).replace("\\", "\\\\").replace("'", "\\'").replace('"', '\\"').replace("`", "\\`")
+
     def _create_payload_for_hunt_indicator(self, action_result, params):
         for key, indicator_type in INDICATOR_MAPPING_JSON_TO_FIELD.items():
             if indicator_to_hunt := params.get(key):
@@ -164,7 +167,7 @@ class ThreatconnectConnector(BaseConnector):
 
         payload = {
             "fields": [],
-            "tql": f"typeName IN ('{indicator_type}') AND summary CONTAINS '{indicator_to_hunt}'",
+            "tql": f"typeName IN ('{indicator_type}') AND summary CONTAINS '{self._escape_tql_literal(indicator_to_hunt)}'",
         }
 
         # Append fields if parameters are present
@@ -176,7 +179,9 @@ class ThreatconnectConnector(BaseConnector):
             else:
                 owners_list = [owner.strip() for owner in owners.replace(";", ",").split(",") if owner.strip()]
 
-            payload["tql"] += f" and ownerName in ({', '.join(map(repr, owners_list))})"
+            payload["tql"] += " and ownerName in ({})".format(
+                ", ".join(f"'{self._escape_tql_literal(owner)}'" for owner in owners_list)
+            )
 
         return phantom.APP_SUCCESS, payload
 

--- a/threatconnect_consts.py
+++ b/threatconnect_consts.py
@@ -1,6 +1,6 @@
 # File: threatconnect_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Previously reviewed scope:

- validates TLS certificates by default, safely escapes hunt query values, and paginates poll indicator requests
- preserves checkpoints after indicator-save failures

July follow-up:

- safely falls back to generic IOC ingestion when a CIDR or Registry Key indicator does not match the required shape
- refreshes connector validation tooling

## Tracking

- PAPP-38079 (ESPM-5228)
- Previously reviewed: PSAAS-31196, PSAAS-31325, PSAAS-32249, PSAAS-32351
- July follow-up: PSAAS-32854

## Validation

- [x] `python3 -m py_compile threatconnect_connector.py`
- [x] Full pre-commit gate under isolated Python 3.13 with public PyPI
- [x] Conventional Commit hook

Written by Codex.