### PR TITLE
fix: sanitize ThreatConnect indicator values

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Refresh ThreatConnect development tooling.
+* Remove Unicode format controls from ingested indicator values.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Refresh ThreatConnect development tooling.

--- a/threatconnect_connector.py
+++ b/threatconnect_connector.py
@@ -20,6 +20,7 @@ import hashlib
 import hmac
 import ipaddress
 import time
+import unicodedata
 from datetime import datetime, timedelta
 
 import phantom.app as phantom
@@ -35,6 +36,10 @@ from requests import Request
 
 # App-specific imports
 from threatconnect_consts import *
+
+
+def _strip_unicode_format_controls(value):
+    return "".join(character for character in value if unicodedata.category(character) != "Cf")
 
 
 class RetVal(tuple):
@@ -445,7 +450,7 @@ class ThreatconnectConnector(BaseConnector):
         for indicator in reversed(indicator_list):
             # Required fields that are present in every Indicator
             required_fields = {
-                "summary": str(indicator["summary"]),
+                "summary": _strip_unicode_format_controls(str(indicator["summary"])),
                 "indicator_type": str(indicator["type"]).lower(),
                 "date_created": str(indicator["dateAdded"]),
                 "date_modified": str(indicator["lastModified"]),


### PR DESCRIPTION
## Summary

- Remove Unicode format-control characters from indicator summaries before ingesting them into SOAR containers and primary CEF fields.

## Tracking

- PAPP-38079
- PSAAS-33175 (VULN-96746, FS-5329)
- ESPM-5228

## Validation

- `python3 -m py_compile threatconnect_connector.py`
- `pre-commit run --all-files`

Written by Codex.